### PR TITLE
Defect split stock

### DIFF
--- a/resources/migrations/006-profit-n-loss.up.sql
+++ b/resources/migrations/006-profit-n-loss.up.sql
@@ -2,6 +2,7 @@ CREATE TABLE st3.profit_n_loss (
     id serial PRIMARY KEY, 
     account_id integer, 
     sale_date DATE NOT NULL, buy_id integer, sale_id integer,
+	cost_price numeric(12,2),
     qty integer NOT NULL,
     charges numeric(12,2) NOT NULL, gain numeric(12,2) NOT NULL, currency char(3) NOT NULL,
     duration_days integer,
@@ -11,7 +12,7 @@ CONSTRAINT fk_sale FOREIGN KEY(sale_id) REFERENCES st3.trades(id));
 --;;
 CREATE VIEW st3.vw_pnl_report AS
 (select gains.id, gains.account_id, gains.sale_date, b.stock, 
-	gains.qty, b.price cost_price, s.price sale_price, 
+	gains.qty, gains.cost_price, s.price sale_price, 
 	(gains.qty * b.price) tco,
 	gains.charges, gain, gains.currency, duration_days, 
 	CASE 

--- a/src/stockmon3/core.clj
+++ b/src/stockmon3/core.clj
@@ -22,7 +22,7 @@
   (let [account-id (Long/parseLong  (:AccountId record))
         acc (get accounts account-id)
         ts (:Date record)
-       
+
         inst (Instant/parse ts)
         date (-> inst
                  (.atOffset (ZoneOffset/ofHoursMinutes 5 30))
@@ -36,29 +36,30 @@
         brokerage (Double/parseDouble (:Brokerage record))
 
         split-pattern #"STOCK SPLIT 1:(\d+)"]
-    ;log(print record)
-    
+
+    ;log (print record)
+
     (cond
 
       (= "0" (:Price record))
       (when-let [[[_, factor]] (re-seq split-pattern notes)]
 
         (split acc  (make-split-event date
-                                    stock
-                                    (Long/parseLong factor)
-                                    (:Notes record)
-                                    account-id)))
+                                      stock
+                                      (Long/parseLong factor)
+                                      (:Notes record)
+                                      account-id)))
       (= "B" type)
-      (let []
-        (buy acc (make-trade date "B" stock qty price brokerage "INR" notes account-id)))
+      (buy acc (make-trade date "B" stock qty price brokerage "INR" notes account-id))
+
       (= "S" type)
-      (let []
-        (sell acc (make-trade date "S" stock qty price brokerage "INR" notes account-id)))
+      (sell acc (make-trade date "S" stock qty price brokerage "INR" notes account-id))
+
       :else
-      (println "ERR Unknown trade pattern " record))
-    
+      (println "ERR Unknown trade pattern " record)))
+
     ;log(println " <3")
-    ))
+    )
   
 
 (defn -main
@@ -77,6 +78,9 @@
                          {} [1 2 3])]
 
     (with-open [reader (io/reader "/mnt/share/acc-3-trades.csv")]
+
+      ; @*#&^@#*^@ BOM character  - https://github.com/clojure/data.csv#byte-order-mark
+      (.skip reader 1)
 
       (->> (csv/read-csv reader)
            csv-data->maps

--- a/src/stockmon3/domain/account.clj
+++ b/src/stockmon3/domain/account.clj
@@ -88,7 +88,7 @@
             updated-holding (assoc holding :rem-qty (- held-qty matched-qty)
                                    :modified true)
             sale (assoc sale :qty-to-match (- sale-qty matched-qty))
-            {:keys [charges net duration-in-days]} (get-trade-stats updated-holding sale matched-qty)
+            {:keys [charges net duration-in-days]} (get-trade-stats holding sale matched-qty)
             gain {:sale_date (:date sale) :buy-id buy-id :sale-id sale-id :qty matched-qty
                   :charges charges :gain net :duration duration-in-days}]
         
@@ -106,10 +106,10 @@
    then total charges for sale_qty=50 => 50+100"
   [buy-trade sale-trade qty]
 
-  (let [{buy-charges :charges, buy-qty :qty cost-price :price buy-date :date} buy-trade
+  (let [{buy-charges :charges, buy-qty :rem-qty cost-price :price buy-date :date} buy-trade
         {sale-charges :charges, sale-qty :qty sale-price :price sale-date :date} sale-trade
-        charges-on-buy (money/multiply buy-charges (/ qty buy-qty) :up)
-        charges-on-sale (money/multiply sale-charges (/ qty sale-qty) :up)
+        charges-on-buy (money/multiply buy-charges (/ qty buy-qty) :half-up)
+        charges-on-sale (money/multiply sale-charges (/ qty sale-qty) :half-up)
         total-charges (money/plus charges-on-buy charges-on-sale)]
 
     {:charges total-charges

--- a/src/stockmon3/domain/account.clj
+++ b/src/stockmon3/domain/account.clj
@@ -79,7 +79,7 @@
   (let [{:keys [sale, updated-holdings, gains]} state-map
         sale-qty (:qty-to-match sale)
         sale-id (:id sale)
-        {held-qty :rem-qty, buy-id :id} holding]
+        {held-qty :rem-qty, buy-id :id, cost-price :price} holding]
     
     
     (if (> sale-qty 0)
@@ -89,8 +89,12 @@
                                    :modified true)
             sale (assoc sale :qty-to-match (- sale-qty matched-qty))
             {:keys [charges net duration-in-days]} (get-trade-stats holding sale matched-qty)
-            gain {:sale_date (:date sale) :buy-id buy-id :sale-id sale-id :qty matched-qty
-                  :charges charges :gain net :duration duration-in-days}]
+            gain {:sale_date (:date sale) 
+                  :buy-id buy-id :cost-price cost-price, 
+                  :sale-id sale-id 
+                  :qty matched-qty
+                  :charges charges :gain net 
+                  :duration duration-in-days}]
         
         (assoc state-map :updated-holdings (conj updated-holdings updated-holding)
                :sale sale

--- a/test/stockmon3/accounts_trade_test.clj
+++ b/test/stockmon3/accounts_trade_test.clj
@@ -132,7 +132,7 @@
         (is (= '("INR 184.75" "INR 28.10") charges)
             "deductions/overheads incorrect")))))
 
-(deftest ^:now test-defect-distribute-charges-on-split-stocks
+(deftest test-defect-distribute-charges-on-split-stocks
   (with-redefs [id-gen/get-next-id mock/get-next-id
                 save-trade identity]
     (let [acc (make-account "customer" "yada")
@@ -150,9 +150,12 @@
           (sell sale-1))
 
       (let [gains (get-gains acc)
+            cost-prices (map #(-> % :cost-price .toString) gains)
             values (map #(-> % :gain .toString) gains)
             charges (map #(-> % :charges .toString) gains)]
-(println gains)
+
+        (is (= '("INR 200.00" "INR 300.00") cost-prices)
+            "cost prices should be updated for stock split")
         (is (= '("INR 183.33" "INR 36.67") charges)
             "deductions/overheads incorrect")
         (is (= '("INR 41066.67" "INR 3213.33") values)

--- a/test/stockmon3/accounts_trade_test.clj
+++ b/test/stockmon3/accounts_trade_test.clj
@@ -6,7 +6,7 @@
              [trade :refer [make-trade make-split-event]]]
             [stockmon3.domain.id-gen :as id-gen]
             [stockmon3.id-gen-mock :as mock]
-            [stockmon3.utils :refer [make-money]]))
+            [stockmon3.utils :refer [make-money money->dbl]]))
 
 
 (deftest test-any-trade-is-recorded
@@ -127,12 +127,12 @@
             values (map #(-> % :gain .toString) gains)
             charges (map #(-> % :charges .toString) gains)]
 
-        (is (= '("INR -1434.75" "INR 6371.90") values)
+        (is (= '("INR -1434.74" "INR 6371.90") values)
             "gain from sales incorrect")
-        (is (= '("INR 184.75" "INR 28.10") charges)
+        (is (= '("INR 184.74" "INR 28.10") charges)
             "deductions/overheads incorrect")))))
 
-(deftest test-defect-distribute-charges-on-split-stocks
+(deftest defect-test-gains-on-split-stocks
   (with-redefs [id-gen/get-next-id mock/get-next-id
                 save-trade identity]
     (let [acc (make-account "customer" "yada")
@@ -164,6 +164,9 @@
 
 ; a bug caused the vector of buys to be turned into a list, causing new buys to be prepended
 (deftest defect-test-sales-are-FIFO
+  ; this test needs deterministic trade ids for verification
+  (mock/reset)
+  
   (with-redefs [id-gen/get-next-id mock/get-next-id
                 save-trade identity]
 
@@ -198,3 +201,27 @@
                (map #(vector (:sale-id %) (:buy-id %) (:qty %))
                     gains))
             "Trades not matched in FIFO order [SaleId BuyId Qty]")))))
+
+(deftest ^:now defect-post-split-test-sales-are-FIFO
+
+  (with-redefs [id-gen/get-next-id mock/get-next-id
+                save-trade identity]
+    (let [acc (make-account "customer" "yada")
+          acc-id (:id acc)]
+
+      (doall (map #(buy acc %)
+                  [(make-trade "2019-08-22" "B" "BFIN" 25 2200.00 0 "INR" "" acc-id)
+                   (make-trade "2019-08-26" "B" "BFIN" 25 2172.15 0 "INR" "" acc-id)]))
+      (split acc  (make-split-event "2019-08-26"
+                                    "BFIN"
+                                    (Long/parseLong "2")
+                                    "STOCK SPLIT 1:2"
+                                    acc-id))
+      (buy acc (make-trade "2020-09-11" "B" "BFIN" 50 1075.00 0 "INR" "" acc-id))
+      (sell acc (make-trade "2020-11-09" "S" "BFIN" 50 1340.00 0 "INR" "" acc-id))
+
+      (let [gains  (get-gains acc)
+            profits (map #(-> % :gain money->dbl) gains)]
+        ; sale should match up with first trades 50@1100
+        (is (= '(12000.0) profits))
+        ))))

--- a/test/stockmon3/id_gen_mock.clj
+++ b/test/stockmon3/id_gen_mock.clj
@@ -4,3 +4,6 @@
 
 (defn get-next-id [entity buffer-size]
   (swap! next-id inc))
+
+(defn reset []
+  (reset! next-id 0))


### PR DESCRIPTION
Stock splits change the effective cost price. On sales, the original cost price must not be used.